### PR TITLE
Removed Event Phot link

### DIFF
--- a/PC2/Views/Shared/_Layout.cshtml
+++ b/PC2/Views/Shared/_Layout.cshtml
@@ -125,7 +125,6 @@
                                         <ul class="dropdown-menu" aria-labelledby="navbarDarkDropdownMenuLink">
                                             <li><a class="dropdown-item" asp-area="" asp-controller="Events" asp-action="Index">Events</a></li>
                                             <li><a class="dropdown-item" asp-area="" asp-controller="Events" asp-action="EventsAndActivities">PC2 Events and Activities</a></li>
-                                            <li><a class="dropdown-item" asp-area="" asp-controller="Home" asp-action="Index">Event Photos</a></li>
                                             <li><a class="dropdown-item" asp-area="" asp-controller="Events" asp-action="CountyWideEventsAndActivities">County-wide Events and Activities</a></li>
                                         </ul>
                                     </li>


### PR DESCRIPTION
The link only went to the index so there was no additional pages to remove.
closes #67 