### PR TITLE
Made duplicate navigation ids unique

### DIFF
--- a/PC2/Views/Shared/_Layout.cshtml
+++ b/PC2/Views/Shared/_Layout.cshtml
@@ -87,10 +87,10 @@ cfg: { // Application Insights Configuration
                                 <a class="nav-link" asp-controller="About" asp-action="HousingProgramData">Housing Program Data</a>
                             </li>
                             <li id="Calendar-Index" class="nav-item menu-item dropdown" >
-                                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDarkDropdown" aria-controls="navbarNavDarkDropdown" aria-expanded="false" aria-label="Toggle navigation">
+                                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDarkDropdown1" aria-controls="navbarNavDarkDropdown1" aria-expanded="false" aria-label="Toggle calendar navigation">
                                     <span class="navbar-toggler-icon d-none"></span>
                                 </button>
-                                <div class="" id="navbarNavDarkDropdown">
+                                <div class="" id="navbarNavDarkDropdown1">
                                     <ul class="navbar-nav priority">
                                         <p class="nav-link dropdown-toggle" href="#" id="navbarDarkDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                         Calendar and Events
@@ -103,10 +103,10 @@ cfg: { // Application Insights Configuration
                                 </div>
                             </li>
                             <li class="nav-item menu-item dropdown" >
-                                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDarkDropdown" aria-controls="navbarNavDarkDropdown" aria-expanded="false" aria-label="Toggle navigation">
+                                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDarkDropdown2" aria-controls="navbarNavDarkDropdown2" aria-expanded="false" aria-label="Toggle member management navigation">
                                     <span class="navbar-toggler-icon d-none"></span>
                                 </button>
-                                <div class="" id="navbarNavDarkDropdown">
+                                <div class="" id="navbarNavDarkDropdown2">
                                     <ul class="navbar-nav priority">                                    
                                         <p class="nav-link dropdown-toggle" href="#" id="navbarDarkDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                         Members
@@ -139,10 +139,10 @@ cfg: { // Application Insights Configuration
                             <a class="nav-link" asp-controller="Events" asp-action="Index">EVENTS</a>           
                         </li>
                         <li id="Resources-Index" class="nav-item menu-item dropdown">
-                            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDarkDropdown" aria-controls="navbarNavDarkDropdown" aria-expanded="false" aria-label="Toggle navigation">
+                            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDarkDropdown3" aria-controls="navbarNavDarkDropdown3" aria-expanded="false" aria-label="Toggle resource navigation">
                                 <span class="navbar-toggler-icon d-none"></span>
                             </button>
-                            <div class="" id="navbarNavDarkDropdown">
+                            <div class="" id="navbarNavDarkDropdown3">
                                 <ul class="navbar-nav priority">                                   
                                     <p class="nav-link dropdown-toggle" href="#" id="navbarDarkDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                     RESOURCES
@@ -165,10 +165,10 @@ cfg: { // Application Insights Configuration
                             <a class="nav-link" asp-area="" asp-controller="Home" asp-action="HousingProgram">PC2's HOUSING PROGRAM</a>
                         </li>
                         <li id="about-menu" class="nav-item menu-item dropdown">
-                            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDarkDropdown" aria-controls="navbarNavDarkDropdown" aria-expanded="false" aria-label="Toggle navigation">
+                            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDarkDropdown4" aria-controls="navbarNavDarkDropdown4" aria-expanded="false" aria-label="Toggle about and contact navigation">
                                     <span class="navbar-toggler-icon d-none"></span>
                                 </button>
-                                <div class="" id="navbarNavDarkDropdown">
+                                <div class="" id="navbarNavDarkDropdown4">
                                     <ul class="navbar-nav priority">
                                         <p class="nav-link dropdown-toggle" href="#" id="navbarDarkDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                         ABOUT US


### PR DESCRIPTION
Closes #205 
The bootstrap documentation shows the ids should be unique but the website does function the same without them. Leaving them in and making them unique to ensure good screen reader support and following the example in the docs
The accessibility checker missed a couple of the duplicates because they only show up when an admin is logged in
Also updated the aria-label attribute to make it more descriptive for screen readers