### PR TITLE
Campbell issue#206-Fixed Bug where navabar did not change for HousingProgram and ProgramVideos when clicked.

### DIFF
--- a/PC2/Views/Shared/_Layout.cshtml
+++ b/PC2/Views/Shared/_Layout.cshtml
@@ -161,7 +161,7 @@ cfg: { // Application Insights Configuration
                                 </ul>
                             </div>
                         </li>
-                        <li class="nav-item menu-item">
+                        <li id="Home-HousingProgram" class="nav-item menu-item">
                             <a class="nav-link" asp-area="" asp-controller="Home" asp-action="HousingProgram">PC2's HOUSING PROGRAM</a>
                         </li>
                         <li id="about-menu" class="nav-item menu-item dropdown">

--- a/PC2/Views/Shared/_Layout.cshtml
+++ b/PC2/Views/Shared/_Layout.cshtml
@@ -129,7 +129,7 @@ cfg: { // Application Insights Configuration
                             <li id="Home-Index" class="nav-item menu-item">
                             <a class="nav-link" asp-area="" asp-controller="Home" asp-action="Index">HOME</a>
                         </li>
-                        <li class="nav-item menu-item">
+                        <li id="ProgramVideos-Index" class="nav-item menu-item">
                             <a class="nav-link" asp-controller="ProgramVideos" asp-action="Index">PROGRAM VIDEOS</a>
                         </li>
                         <li id="NewsToKnow-Index" class="nav-item menu-item">


### PR DESCRIPTION
Closes #206 
Added missing id to both ProgramVideos link and HousingProgram link in the navbar which is needed to show which page you are on properly.