### PR TITLE
Issue#210 data not sorted

### DIFF
--- a/PC2/Data/AgencyDB.cs
+++ b/PC2/Data/AgencyDB.cs
@@ -130,6 +130,7 @@ namespace PC2.Data
                 .Where(agency => agency.AgencyCategories
                 .Where(cat => cat.AgencyCategoryName == categoryName)
                 .Any())
+                .OrderBy(agency => agency.AgencyName)
                 .ToListAsync();
         }
 

--- a/PC2/Data/AgencyDB.cs
+++ b/PC2/Data/AgencyDB.cs
@@ -41,12 +41,14 @@ namespace PC2.Data
         }
 
         /// <summary>
-        /// Gets all agencies from the database
+        /// Gets all agencies from the database in alphabetical order by Agency Name
         /// </summary>
         public static async Task<List<Agency>> GetAllAgenciesAsync(ApplicationDbContext context)
         {
             return await (from a in context.Agency
-                          select a).Include(nameof(Agency.AgencyCategories)).ToListAsync();
+                          select a).Include(nameof(Agency.AgencyCategories))
+                          .OrderBy(agency => agency.AgencyName)
+                          .ToListAsync();
         }
 
         public static async Task<int> GetAgencyCountAsync(ApplicationDbContext context)

--- a/PC2/Data/AgencyDB.cs
+++ b/PC2/Data/AgencyDB.cs
@@ -97,11 +97,20 @@ namespace PC2.Data
             return result;
         }
 
+        /// <summary>
+        /// Returns a list of Agencies in a specific city in alphabetical order
+        /// by AgencyName
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="city">City the user is searching by</param>
+        /// <returns></returns>
         public static async Task<List<Agency>> GetSpecificAgenciesAsync(ApplicationDbContext context, string city)
         {
             return await (from a in context.Agency
-                          where a.City !=  null && a.City == city
-                          select a).Include(nameof(Agency.AgencyCategories)).ToListAsync();
+                          where a.City != null && a.City == city
+                          select a).Include(nameof(Agency.AgencyCategories))
+                          .OrderBy(agency => agency.AgencyName)
+                          .ToListAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
Resource Guide results were not sorted in alphabetical order when searching by Agency Service or by searching the city. Both of those scenarios were fixed