### PR TITLE
navbar switches to dropdown menu bar before overflow occurs

### DIFF
--- a/PC2/Views/Shared/_Layout.cshtml
+++ b/PC2/Views/Shared/_Layout.cshtml
@@ -63,7 +63,7 @@ cfg: { // Application Insights Configuration
                 </h1>
             </div>
         </div>
-        <nav class="navbar navbar-expand-md navbar-toggleable-md navbar-dark border-bottom border-top box-shadow mb-3">
+        <nav class="navbar navbar-expand-lg navbar-toggleable-lg navbar-dark border-bottom border-top box-shadow mb-3">
             <div class="container">
                 <div id="menu-bar">
                     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
@@ -76,7 +76,7 @@ cfg: { // Application Insights Configuration
                 </div>
                 <div id="left-ribbon" class="ribbon"></div>
                 <div id="right-ribbon" class="ribbon"></div>
-                <div class="navbar-collapse collapse d-md-inline-flex flex-md-row-reverse" id="navbarSupportedContent">
+                <div class="navbar-collapse collapse d-lg-inline-flex flex-lg-row-reverse" id="navbarSupportedContent">
                     <ul class="navbar-nav flex-grow-1">
                         @if (User.IsInRole(IdentityHelper.Admin))
                         {

--- a/PC2/wwwroot/css/site.css
+++ b/PC2/wwwroot/css/site.css
@@ -359,7 +359,8 @@ nav a {
     display: block;
 }*/
 
-@media only screen and (min-width: 768px) {
+/*min-width should match the breakpoint for <nav>*/
+@media only screen and (min-width: 992px) {
     html {
         font-size: 16px;
     }
@@ -382,7 +383,8 @@ nav a {
     }
 }
 
-@media only screen and (max-width: 768px) {
+/*max-width should be 1px less than the breakpoint for <nav>*/
+@media only screen and (max-width: 991px) {
     /*Centers menu items when navbar collapses*/
     #bootstrap-override .menu-item a {
         height: inherit;


### PR DESCRIPTION
![container overflow](https://user-images.githubusercontent.com/95327043/222875039-a0f8b756-d91a-4fb4-9b68-9b232d225e13.png)
resolves #109 
The right-ribbon div is behaving properly. The div containing the nav however is overflowing. Once the screens width is below 976 pixels, the overflow begins. This solution would change the breakpoint from 'md' to 'lg', so the menu bar now appears at 992 pixels width. Well before the overflow occurs.