### PR TITLE
Resource guide links bug

### DIFF
--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -154,7 +154,7 @@
                 {
                     <tr>
                         <td>
-                            <a class="left-agency" asp-action="ResourceGuide" asp-route-categoryID="@Model.AgencyCategoriesForDataList[i].AgencyCategoryId" asp-route-yPosition="tempY">
+                            <a class="left-agency" asp-action="ResourceGuide" asp-route-categoryID="@Model.AgencyCategoriesForDataList[i].AgencyCategoryId">
                                 @Html.DisplayFor(modelItem => Model.AgencyCategoriesForDataList.ElementAt(i).AgencyCategoryName)
                             </a>
                         </td>
@@ -172,7 +172,7 @@
                 {
                     <tr>
                         <td>
-                            <a class="right-agency" asp-action="ResourceGuide" asp-route-categoryID="@Model.AgencyCategoriesForDataList[i].AgencyCategoryId" asp-route-yPosition="tempY">
+                            <a class="right-agency" asp-action="ResourceGuide" asp-route-categoryID="@Model.AgencyCategoriesForDataList[i].AgencyCategoryId">
                                 @Html.DisplayFor(modelItem => Model.AgencyCategoriesForDataList.ElementAt(i).AgencyCategoryName)
                             </a>
                         </td>

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -154,7 +154,7 @@
                 {
                     <tr>
                         <td>
-                            <a class="left-agency" asp-action="ResourceGuide" asp-route-categoryID="@(i + 1)" asp-route-yPosition="tempY">
+                            <a class="left-agency" asp-action="ResourceGuide" asp-route-categoryID="@Model.AgencyCategoriesForDataList[i].AgencyCategoryId" asp-route-yPosition="tempY">
                                 @Html.DisplayFor(modelItem => Model.AgencyCategoriesForDataList.ElementAt(i).AgencyCategoryName)
                             </a>
                         </td>
@@ -172,7 +172,7 @@
                 {
                     <tr>
                         <td>
-                            <a class="right-agency" asp-action="ResourceGuide" asp-route-categoryID="@(i + 1)" asp-route-yPosition="tempY">
+                            <a class="right-agency" asp-action="ResourceGuide" asp-route-categoryID="@Model.AgencyCategoriesForDataList[i].AgencyCategoryId" asp-route-yPosition="tempY">
                                 @Html.DisplayFor(modelItem => Model.AgencyCategoriesForDataList.ElementAt(i).AgencyCategoryName)
                             </a>
                         </td>


### PR DESCRIPTION
The original code used an iterator variable to point to the service category id. It looks like the client had renamed or removed on of the categories causing that number to be out of sync with the actual categoryID. The categoryID from the database is now being used when generating all the links