### PR TITLE
Issue#230 resource guide results layout

### DIFF
--- a/PC2/Controllers/ResourcesController.cs
+++ b/PC2/Controllers/ResourcesController.cs
@@ -85,6 +85,8 @@ namespace PC2.Controllers
                     TrackResourceGuideTelemetry("CityAndCategory", $"{searchModel.SearchedCity} - {searchModel.SearchedCategory}");
                     resourceGuide.Agencies = await AgencyDB.GetAgenciesByCategoryAndCity(_context,
                         searchModel.SearchedCategory, searchModel.SearchedCity);
+                    resourceGuide.CurrentCity = searchModel.SearchedCity;
+                    resourceGuide.Category = await AgencyCategoryDB.GetAgencyCategory(_context, searchModel.SearchedCategory);
                 }
                 else if (searchModel.SearchedCategory != null)
                 {

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -201,216 +201,217 @@ else
                 </div>
             </div>
         }
-
-        @for (int i = 0; i < Model.Agencies.Count; i++)
-        {
-            <div class="row py-1 results @(i % 2 != 0 ? "" : "odd-row")">
-                    <div class="col-md-5">
-                    @Model.Agencies[i].AgencyName
-                    @if (Model.Agencies[i].AgencyName2 != null)
-                    {
-                        <p id="agencyName2"> @Model.Agencies[i].AgencyName2 </p>
-                    }
-                    </div>
-                <div class="col-md-5">
-                    @if (Model.Agencies[i].Phone != null)
-                    {
-                        string phoneNumber = Model.Agencies[i].Phone;
-
-                        @if (phoneNumber.Substring(0, 3) == "tel")
+        <div id="scrollResults" class="container">
+            @for (int i = 0; i < Model.Agencies.Count; i++)
+            {
+                <div class="row py-1 results @(i % 2 != 0 ? "" : "odd-row")">
+                        <div class="col-md-5">
+                        @Model.Agencies[i].AgencyName
+                        @if (Model.Agencies[i].AgencyName2 != null)
                         {
-                            <a href="@phoneNumber">@phoneNumber</a>
+                            <p id="agencyName2"> @Model.Agencies[i].AgencyName2 </p>
                         }
-                        @*handle inconsistencies in phone number data*@
+                        </div>
+                    <div class="col-md-5">
+                        @if (Model.Agencies[i].Phone != null)
+                        {
+                            string phoneNumber = Model.Agencies[i].Phone;
+
+                            @if (phoneNumber.Substring(0, 3) == "tel")
+                            {
+                                <a href="@phoneNumber">@phoneNumber</a>
+                            }
+                            @*handle inconsistencies in phone number data*@
+                            else
+                            {
+                                @for (int j = 0; j < phoneNumber.Length; j++)
+                                {
+                                    // if the string contains "(xxx)"
+                                    if (phoneNumber[j] == '(' && phoneNumber[j + 4] == ')')
+                                    {
+                                        @if (j > 0)
+                                        {
+                                            <br>
+                                        }
+                                        // display phone number as clickable number and move to the end of it
+                                        <a href="tel:@phoneNumber.Substring(j, 14)">@phoneNumber.Substring(j, 14)</a>
+                                        j += 14;
+                                    }
+                                    else // display the character
+                                    {
+                                        @phoneNumber[j]
+                                        ;
+                                    }
+                                }
+                            }
+                            <br />
+                        }
+
+                        @if (Model.Agencies[i].Email != null)
+                        {
+                            string email = Model.Agencies[i].Email;
+                            int emailStart = 0;
+
+                            @*separate multiple emails*@
+                            @for (int j = 0; j < email.Length; j++)
+                            {
+                                // if the email contains a space
+                                if (email[j] == ' ')
+                                {
+                                    // display all characters from emailStart to current index as link
+                                    string singleEmail = email.Substring(emailStart, j - emailStart);
+                                    <a href="mailto:@singleEmail">@singleEmail</a>
+                                    <br>
+                                    emailStart = j;
+                                }
+                            }
+                            // display link as final email
+                            string finalEmail = email.Substring(emailStart, email.Length - emailStart);
+
+                            <a href="mailto:@finalEmail.Trim()">@finalEmail</a>
+                        }
+                        </div>
+
+                        @if (Model.Agencies[i].City != null)
+                        {
+                            <div class="col-md-1">@Model.Agencies[i].City : @Model.Agencies[i].Zip</div>
+                        }
                         else
                         {
-                            @for (int j = 0; j < phoneNumber.Length; j++)
-                            {
-                                // if the string contains "(xxx)"
-                                if (phoneNumber[j] == '(' && phoneNumber[j + 4] == ')')
-                                {
-                                    @if (j > 0)
-                                    {
-                                        <br>
-                                    }
-                                    // display phone number as clickable number and move to the end of it
-                                    <a href="tel:@phoneNumber.Substring(j, 14)">@phoneNumber.Substring(j, 14)</a>
-                                    j += 14;
-                                }
-                                else // display the character
-                                {
-                                    @phoneNumber[j]
-                                    ;
-                                }
-                            }
+                            <div></div>
                         }
-                        <br />
-                    }
+                        <div class="col-md-1">
+                            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#detailsModal-@i">
+                                Details
+                            </button>
 
-                    @if (Model.Agencies[i].Email != null)
-                    {
-                        string email = Model.Agencies[i].Email;
-                        int emailStart = 0;
-
-                        @*separate multiple emails*@
-                        @for (int j = 0; j < email.Length; j++)
-                        {
-                            // if the email contains a space
-                            if (email[j] == ' ')
-                            {
-                                // display all characters from emailStart to current index as link
-                                string singleEmail = email.Substring(emailStart, j - emailStart);
-                                <a href="mailto:@singleEmail">@singleEmail</a>
-                                <br>
-                                emailStart = j;
-                            }
-                        }
-                        // display link as final email
-                        string finalEmail = email.Substring(emailStart, email.Length - emailStart);
-
-                        <a href="mailto:@finalEmail.Trim()">@finalEmail</a>
-                    }
-                    </div>
-
-                    @if (Model.Agencies[i].City != null)
-                    {
-                        <div class="col-md-1">@Model.Agencies[i].City : @Model.Agencies[i].Zip</div>
-                    }
-                    else
-                    {
-                        <div></div>
-                    }
-                    <div class="col-md-1">
-                        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#detailsModal-@i">
-                            Details
-                        </button>
-
-                        <div class="modal fade" id="detailsModal-@i" data-bs-keyboard="false" tabindex="-1" aria-labelledby="detailsModalLabel" aria-hidden="true" style="color: black">
-                            <div class="modal-dialog modal-lg">
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        <h1 class="modal-title fs-5" id="detailsModalLabel">@Model.Agencies[i].AgencyName</h1>
-                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                    </div>
-                                    <div class="modal-body">
-                                        <dl class="row">
-                                            @*For each property in class agency*@
-                                            @foreach(var prop in typeof(Agency).GetProperties())
-                                            {
-
-                                                if (prop.GetValue(Model.Agencies[i]) != null)
+                            <div class="modal fade" id="detailsModal-@i" data-bs-keyboard="false" tabindex="-1" aria-labelledby="detailsModalLabel" aria-hidden="true" style="color: black">
+                                <div class="modal-dialog modal-lg">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h1 class="modal-title fs-5" id="detailsModalLabel">@Model.Agencies[i].AgencyName</h1>
+                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <dl class="row">
+                                                @*For each property in class agency*@
+                                                @foreach(var prop in typeof(Agency).GetProperties())
                                                 {
-                                                    // handles email links
-                                                    if (prop.Name == "Email")
-                                                    {
-                                                        <dt>@prop.Name</dt>
-                                                        string emailData = prop.GetValue(Model.Agencies[i]).ToString();
-                                                        @*separate multiple emails*@
-                                                        <dd>
-                                                            @{
-                                                                if (emailData != null)
-                                                                {
-                                                                    string[] emails = emailData.Split(' ');
-                                                                    foreach(string email in emails)
-                                                                    {
-                                                                        <a href="mailto:@email.Trim()">
-                                                                            @email
-                                                                        </a>
-                                                                        <br>
-                                                                    }
-                                                                }
-                                                            }
-                                                        </dd>
-                                                    }
-                                                    // handles phone links
-                                                    else if (prop.Name == "Phone")
-                                                    {
-                                                        <dt>@prop.Name</dt>
-                                                        string phone = prop.GetValue(Model.Agencies[i]).ToString();
 
-                                                        if (phone.Length > 15)
+                                                    if (prop.GetValue(Model.Agencies[i]) != null)
+                                                    {
+                                                        // handles email links
+                                                        if (prop.Name == "Email")
                                                         {
-                                                            @*handle inconsistencies in phone number data*@ // borrowed from code above
+                                                            <dt>@prop.Name</dt>
+                                                            string emailData = prop.GetValue(Model.Agencies[i]).ToString();
+                                                            @*separate multiple emails*@
                                                             <dd>
-                                                                @for (int j = 0; j < phone.Length; j++)
-                                                                {
-                                                                    // if the string contains "(xxx)"
-                                                                    if (phone[j] == '(' && phone[j + 4] == ')')
+                                                                @{
+                                                                    if (emailData != null)
                                                                     {
-                                                                        @if (j > 0)
+                                                                        string[] emails = emailData.Split(' ');
+                                                                        foreach(string email in emails)
                                                                         {
+                                                                            <a href="mailto:@email.Trim()">
+                                                                                @email
+                                                                            </a>
                                                                             <br>
                                                                         }
-                                                                        // display phone number as clickable number and move to the end of it
-                                                                        <a href="tel:@phone.Substring(j, 14)">@phone.Substring(j, 14)</a>
-                                                                        <br>
-                                                                        j += 14;
-                                                                    }
-                                                                    else // display the character
-                                                                    {
-                                                                        @phone[j];
                                                                     }
                                                                 }
                                                             </dd>
                                                         }
-
-                                                        else
-                                                        {
-                                                            <dd><a href="tel:@prop.GetValue(Model.Agencies[i])">@prop.GetValue(Model.Agencies[i])</a></dd>
-                                                        }
-                                                    }
-                                                    // handles website links
-                                                    else if (prop.Name == "Website")
-                                                    {
-                                                        <dt>@prop.Name</dt>
-                                                        string websiteString = prop.GetValue(Model.Agencies[i]).ToString();
-                                                        int start = 0;
-
-                                                        if (websiteString != null)
-                                                        {
-                                                            string[] websites = websiteString.Split(' ');
-                                                            foreach(string website in websites)
-                                                            {
-                                                                string url = website.Trim();
-                                                                // if the url is empty, skip it. This is to handle extra spaces in the data
-                                                                if (url == string.Empty)
-                                                                {
-                                                                    continue;
-                                                                }
-                                                                if (!url.StartsWith("https://") && !url.StartsWith("http://"))
-                                                                {
-                                                                    url = "https://" + url;
-                                                                }
-                                                                <dd><a href="@url">@url</a></dd>
-                                                            }
-                                                        }
-                                                    }
-                                                    // excludes certain columns and displays the rest
-                                                    else if (prop.Name != "AgencyCategories" && prop.Name != "AgencyId" && prop.Name != "AgencyName")
-                                                    {
-                                                        if (prop.Name == "Address1" && Model.Agencies[i].Address2 == null)
-                                                        {
-                                                            <dt>Address</dt>
-                                                        }
-                                                        else
+                                                        // handles phone links
+                                                        else if (prop.Name == "Phone")
                                                         {
                                                             <dt>@prop.Name</dt>
+                                                            string phone = prop.GetValue(Model.Agencies[i]).ToString();
+
+                                                            if (phone.Length > 15)
+                                                            {
+                                                                @*handle inconsistencies in phone number data*@ // borrowed from code above
+                                                                <dd>
+                                                                    @for (int j = 0; j < phone.Length; j++)
+                                                                    {
+                                                                        // if the string contains "(xxx)"
+                                                                        if (phone[j] == '(' && phone[j + 4] == ')')
+                                                                        {
+                                                                            @if (j > 0)
+                                                                            {
+                                                                                <br>
+                                                                            }
+                                                                            // display phone number as clickable number and move to the end of it
+                                                                            <a href="tel:@phone.Substring(j, 14)">@phone.Substring(j, 14)</a>
+                                                                            <br>
+                                                                            j += 14;
+                                                                        }
+                                                                        else // display the character
+                                                                        {
+                                                                            @phone[j];
+                                                                        }
+                                                                    }
+                                                                </dd>
+                                                            }
+
+                                                            else
+                                                            {
+                                                                <dd><a href="tel:@prop.GetValue(Model.Agencies[i])">@prop.GetValue(Model.Agencies[i])</a></dd>
+                                                            }
                                                         }
-                                                        <dd>@prop.GetValue(Model.Agencies[i])</dd>
+                                                        // handles website links
+                                                        else if (prop.Name == "Website")
+                                                        {
+                                                            <dt>@prop.Name</dt>
+                                                            string websiteString = prop.GetValue(Model.Agencies[i]).ToString();
+                                                            int start = 0;
+
+                                                            if (websiteString != null)
+                                                            {
+                                                                string[] websites = websiteString.Split(' ');
+                                                                foreach(string website in websites)
+                                                                {
+                                                                    string url = website.Trim();
+                                                                    // if the url is empty, skip it. This is to handle extra spaces in the data
+                                                                    if (url == string.Empty)
+                                                                    {
+                                                                        continue;
+                                                                    }
+                                                                    if (!url.StartsWith("https://") && !url.StartsWith("http://"))
+                                                                    {
+                                                                        url = "https://" + url;
+                                                                    }
+                                                                    <dd><a href="@url">@url</a></dd>
+                                                                }
+                                                            }
+                                                        }
+                                                        // excludes certain columns and displays the rest
+                                                        else if (prop.Name != "AgencyCategories" && prop.Name != "AgencyId" && prop.Name != "AgencyName")
+                                                        {
+                                                            if (prop.Name == "Address1" && Model.Agencies[i].Address2 == null)
+                                                            {
+                                                                <dt>Address</dt>
+                                                            }
+                                                            else
+                                                            {
+                                                                <dt>@prop.Name</dt>
+                                                            }
+                                                            <dd>@prop.GetValue(Model.Agencies[i])</dd>
+                                                        }
                                                     }
                                                 }
-                                            }
-                                        </dl>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                                            </dl>
+                                        </div>
+                                        <div class="modal-footer">
+                                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
-                    </div>                
-            </div>
-        }
+                        </div>                
+                </div>
+            }
+        </div>
     </div>
 }
 

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -214,15 +214,13 @@ else
             @for (int i = 0; i < Model.Agencies.Count; i++)
             {
                 <tr>
-                    <td>@Model.Agencies[i].AgencyName</td>
-                    @if (Model.Agencies[i].AgencyName2 != null)
-                    {
-                        <td>@Model.Agencies[i].AgencyName2</td>
-                    }
-                    else
-                    {
-                        <td></td>
-                    }
+                    <td>
+                        @Model.Agencies[i].AgencyName
+                        @if (Model.Agencies[i].AgencyName2 != null)
+                        {
+                            <p id="agencyName2"> @Model.Agencies[i].AgencyName2 </p>
+                        }
+                    </td>
                     @if (Model.Agencies[i].Phone != null)
                     {
                         string phoneNumber = Model.Agencies[i].Phone;

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -205,7 +205,7 @@ else
         <div id="scrollResults" class="container">
             @for (int i = 0; i < Model.Agencies.Count; i++)
             {
-                <div class="row py-1 results @(i % 2 == 0 ? "evenIndex-row" : "")"> <!--css for evenIndex-row to emulate striped table-->
+                <div class="row py-1 results"> <!--css for evenIndex-row to emulate striped table-->
                     <div class="col-md-5 col-9">
                         @Model.Agencies[i].AgencyName 
                         @if (Model.CurrentCity == null && Model.Agencies[i].City != null)

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -185,34 +185,38 @@
 else
 {
     <div id="results" class="container">
-
-            <div class="row">
-            <h1>
-                @if (Model.Category != null && Model.CurrentCity != null)
-                {
-                    @:@Model.Category.AgencyCategoryName - @Model.CurrentCity
-        }
-                else if (Model.Category != null)
-                {
-                    @: @Model.Category.AgencyCategoryName
-                }
-        else if (Model.CurrentCity != null)
-        {
-                    @: @Model.CurrentCity
-                }
-            </h1>
-                </div>
+        
+        <div class="row">
+        <h1>
+            @if (Model.Category != null && Model.CurrentCity != null)
+            {
+                @:@Model.Category.AgencyCategoryName - @Model.CurrentCity
+            }
+            else if (Model.Category != null)
+            {
+                @: @Model.Category.AgencyCategoryName
+            }
+            else if (Model.CurrentCity != null)
+            {
+                @: @Model.CurrentCity
+            }
+        </h1>
+    </div>
         <div id="scrollResults" class="container">
             @for (int i = 0; i < Model.Agencies.Count; i++)
             {
                 <div class="row py-1 results @(i % 2 == 0 ? "evenIndex-row" : "")">
-                        <div class="col-md-5">
-                        @Model.Agencies[i].AgencyName
+                    <div class="col-md-5">
+                        @Model.Agencies[i].AgencyName 
+                        @if (Model.CurrentCity == null && Model.Agencies[i].City != null)
+                        {
+                            @(" - " + Model.Agencies[i].City)
+                        }
                         @if (Model.Agencies[i].AgencyName2 != null)
                         {
                             <p id="agencyName2"> @Model.Agencies[i].AgencyName2 </p>
                         }
-                        </div>
+                    </div>
                     <div class="col-md-5">
                         @if (Model.Agencies[i].Phone != null)
                         {
@@ -240,8 +244,7 @@ else
                                     }
                                     else // display the character
                                     {
-                                        @phoneNumber[j]
-                                        ;
+                                        @phoneNumber[j];
                                     }
                                 }
                             }
@@ -273,15 +276,7 @@ else
                         }
                         </div>
 
-                        @if (Model.Agencies[i].City != null)
-                        {
-                            <div class="col-md-1">@Model.Agencies[i].City : @Model.Agencies[i].Zip</div>
-                        }
-                        else
-                        {
-                            <div></div>
-                        }
-                        <div class="col-md-1">
+                        <div class="col-1">
                             <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#detailsModal-@i">
                                 Details
                             </button>

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -184,102 +184,103 @@
 }
 else
 {
-    <div id="results" class="table-responsive">
-        <table class="table table-striped table-hover">
-            @if (Model.Category != null)
-            {
-                <thead>
-                    <tr>
-                        <h1>@Model.Category.AgencyCategoryName</h1>
-                    </tr>
-                </thead>
-            }
-            else if (Model.CurrentCity != null)
-            {
-                <thead>
-                    <tr>
-                        <h1>@Model.CurrentCity</h1>
-                    </tr>
-                </thead>
-            }
+    <div id="results" class="container">
+        @if (Model.Category != null)
+        {
+            <div class="row">
+                <div class="col-12">
+                    <h1>@Model.Category.AgencyCategoryName</h1>
+                </div>
+            </div>
+        }
+        else if (Model.CurrentCity != null)
+        {
+            <div class="row">
+                <div class="col-12">
+                    <h1>@Model.CurrentCity</h1>
+                </div>
+            </div>
+        }
 
-            @for (int i = 0; i < Model.Agencies.Count; i++)
-            {
-                <tr>
-                    <td>
-                        @Model.Agencies[i].AgencyName
-                        @if (Model.Agencies[i].AgencyName2 != null)
-                        {
-                            <p id="agencyName2"> @Model.Agencies[i].AgencyName2 </p>
-                        }
-                    </td>
-                    <td>
-                        @if (Model.Agencies[i].Phone != null)
-                        {
-                            string phoneNumber = Model.Agencies[i].Phone;
+        @for (int i = 0; i < Model.Agencies.Count; i++)
+        {
+            <div class="row py-1 results @(i % 2 != 0 ? "" : "odd-row")">
+                    <div class="col-md-5">
+                    @Model.Agencies[i].AgencyName
+                    @if (Model.Agencies[i].AgencyName2 != null)
+                    {
+                        <p id="agencyName2"> @Model.Agencies[i].AgencyName2 </p>
+                    }
+                    </div>
+                <div class="col-md-5">
+                    @if (Model.Agencies[i].Phone != null)
+                    {
+                        string phoneNumber = Model.Agencies[i].Phone;
 
-                            @if (phoneNumber.Substring(0, 3) == "tel")
-                            {
+                        @if (phoneNumber.Substring(0, 3) == "tel")
+                        {
                             <a href="@phoneNumber">@phoneNumber</a>
-                            }
-                            @*handle inconsistencies in phone number data*@
-                            else
-                            {
-                                @for (int j = 0; j < phoneNumber.Length; j++)
-                                {
-                                    // if the string contains "(xxx)"
-                                    if (phoneNumber[j] == '(' && phoneNumber[j + 4] == ')')
-                                    {
-                                        @if (j > 0) {
-                                            <br>
-                                        }
-                                        // display phone number as clickable number and move to the end of it
-                                        <a href="tel:@phoneNumber.Substring(j, 14)">@phoneNumber.Substring(j, 14)</a>
-                                        j += 14;
-                                    }
-                                    else // display the character
-                                    {
-                                        @phoneNumber[j];
-                                    }                          
-                                }
-                            }
-                            <br />
                         }
-
-                        @if (Model.Agencies[i].Email != null)
+                        @*handle inconsistencies in phone number data*@
+                        else
                         {
-                            string email = Model.Agencies[i].Email;
-                            int emailStart = 0;
-
-                            @*separate multiple emails*@
-                            @for (int j = 0; j < email.Length; j++)
+                            @for (int j = 0; j < phoneNumber.Length; j++)
                             {
-                                // if the email contains a space
-                                if (email[j] == ' ')
+                                // if the string contains "(xxx)"
+                                if (phoneNumber[j] == '(' && phoneNumber[j + 4] == ')')
                                 {
-                                    // display all characters from emailStart to current index as link
-                                    string singleEmail = email.Substring(emailStart, j - emailStart);
-                                    <a href="mailto:@singleEmail">@singleEmail</a>
-                                    <br>
-                                    emailStart = j;
+                                    @if (j > 0)
+                                    {
+                                        <br>
+                                    }
+                                    // display phone number as clickable number and move to the end of it
+                                    <a href="tel:@phoneNumber.Substring(j, 14)">@phoneNumber.Substring(j, 14)</a>
+                                    j += 14;
+                                }
+                                else // display the character
+                                {
+                                    @phoneNumber[j]
+                                    ;
                                 }
                             }
-                             // display link as final email
-                             string finalEmail = email.Substring(emailStart, email.Length - emailStart);
-                            
-                            <a href="mailto:@finalEmail.Trim()">@finalEmail</a>
                         }
-                    </td>
+                        <br />
+                    }
+
+                    @if (Model.Agencies[i].Email != null)
+                    {
+                        string email = Model.Agencies[i].Email;
+                        int emailStart = 0;
+
+                        @*separate multiple emails*@
+                        @for (int j = 0; j < email.Length; j++)
+                        {
+                            // if the email contains a space
+                            if (email[j] == ' ')
+                            {
+                                // display all characters from emailStart to current index as link
+                                string singleEmail = email.Substring(emailStart, j - emailStart);
+                                <a href="mailto:@singleEmail">@singleEmail</a>
+                                <br>
+                                emailStart = j;
+                            }
+                        }
+                        // display link as final email
+                        string finalEmail = email.Substring(emailStart, email.Length - emailStart);
+
+                        <a href="mailto:@finalEmail.Trim()">@finalEmail</a>
+                    }
+                    </div>
 
                     @if (Model.Agencies[i].City != null)
                     {
-                        <td>@Model.Agencies[i].City : @Model.Agencies[i].Zip</td>
+                        <div class="col-md-1">@Model.Agencies[i].City : @Model.Agencies[i].Zip</div>
                     }
                     else
                     {
-                        <td></td>
+                        <div></div>
                     }
-                    <td>
+                    <div class="col-md-1">
                         <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#detailsModal-@i">
                             Details
                         </button>
@@ -294,9 +295,9 @@ else
                                     <div class="modal-body">
                                         <dl class="row">
                                             @*For each property in class agency*@
-                                            @foreach (var prop in typeof(Agency).GetProperties())
+                                            @foreach(var prop in typeof(Agency).GetProperties())
                                             {
-                                                
+
                                                 if (prop.GetValue(Model.Agencies[i]) != null)
                                                 {
                                                     // handles email links
@@ -326,33 +327,33 @@ else
                                                     {
                                                         <dt>@prop.Name</dt>
                                                         string phone = prop.GetValue(Model.Agencies[i]).ToString();
-                                                        
+
                                                         if (phone.Length > 15)
                                                         {
                                                             @*handle inconsistencies in phone number data*@ // borrowed from code above
                                                             <dd>
-                                                            @for (int j = 0; j < phone.Length; j++)
-                                                            {
-                                                                // if the string contains "(xxx)"
-                                                                if (phone[j] == '(' && phone[j + 4] == ')')
+                                                                @for (int j = 0; j < phone.Length; j++)
                                                                 {
-                                                                    @if (j > 0)
+                                                                    // if the string contains "(xxx)"
+                                                                    if (phone[j] == '(' && phone[j + 4] == ')')
                                                                     {
+                                                                        @if (j > 0)
+                                                                        {
+                                                                            <br>
+                                                                        }
+                                                                        // display phone number as clickable number and move to the end of it
+                                                                        <a href="tel:@phone.Substring(j, 14)">@phone.Substring(j, 14)</a>
                                                                         <br>
+                                                                        j += 14;
                                                                     }
-                                                                    // display phone number as clickable number and move to the end of it
-                                                                    <a href="tel:@phone.Substring(j, 14)">@phone.Substring(j, 14)</a>
-                                                                    <br>
-                                                                    j += 14;
+                                                                    else // display the character
+                                                                    {
+                                                                        @phone[j];
+                                                                    }
                                                                 }
-                                                                else // display the character
-                                                                {
-                                                                    @phone[j];
-                                                                }
-                                                            }
                                                             </dd>
                                                         }
-                                                        
+
                                                         else
                                                         {
                                                             <dd><a href="tel:@prop.GetValue(Model.Agencies[i])">@prop.GetValue(Model.Agencies[i])</a></dd>
@@ -407,10 +408,9 @@ else
                                 </div>
                             </div>
                         </div>
-                    </td>
-                </tr>
-            }
-        </table>
+                    </div>                
+            </div>
+        }
     </div>
 }
 

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -204,7 +204,7 @@ else
         <div id="scrollResults" class="container">
             @for (int i = 0; i < Model.Agencies.Count; i++)
             {
-                <div class="row py-1 results @(i % 2 != 0 ? "" : "odd-row")">
+                <div class="row py-1 results @(i % 2 == 0 ? "evenIndex-row" : "")">
                         <div class="col-md-5">
                         @Model.Agencies[i].AgencyName
                         @if (Model.Agencies[i].AgencyName2 != null)

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -190,11 +190,7 @@ else
             {
                 <thead>
                     <tr>
-                        <td></td>
-                        <td></td>
-                        <td><h1>@Model.Category.AgencyCategoryName</h1></td>
-                        <td></td>
-                        <td></td>
+                        <h1>@Model.Category.AgencyCategoryName</h1>
                     </tr>
                 </thead>
             }
@@ -202,11 +198,7 @@ else
             {
                 <thead>
                     <tr>
-                        <td></td>
-                        <td></td>
-                        <td><h1>@Model.CurrentCity</h1></td>
-                        <td></td>
-                        <td></td>
+                        <h1>@Model.CurrentCity</h1>
                     </tr>
                 </thead>
             }
@@ -221,49 +213,44 @@ else
                             <p id="agencyName2"> @Model.Agencies[i].AgencyName2 </p>
                         }
                     </td>
-                    @if (Model.Agencies[i].Phone != null)
-                    {
-                        string phoneNumber = Model.Agencies[i].Phone;
-                        
-                        <td>
-                        @if (phoneNumber.Substring(0, 3) == "tel")
+                    <td>
+                        @if (Model.Agencies[i].Phone != null)
                         {
-                            <a href="@phoneNumber)">phoneNumber</a>
-                        }
-                        @*handle inconsistencies in phone number data*@
-                        else
-                        {
-                            @for (int j = 0; j < phoneNumber.Length; j++)
+                            string phoneNumber = Model.Agencies[i].Phone;
+
+                            @if (phoneNumber.Substring(0, 3) == "tel")
                             {
-                                // if the string contains "(xxx)"
-                                if (phoneNumber[j] == '(' && phoneNumber[j + 4] == ')')
-                                {
-                                    @if (j > 0) {
-                                        <br>
-                                    }
-                                    // display phone number as clickable number and move to the end of it
-                                    <a href="tel:@phoneNumber.Substring(j, 14)">@phoneNumber.Substring(j, 14)</a>
-                                    <br>                               
-                                    j += 14;
-                                }
-                                else // display the character
-                                {
-                                    @phoneNumber[j];
-                                }                          
+                            <a href="@phoneNumber">@phoneNumber</a>
                             }
+                            @*handle inconsistencies in phone number data*@
+                            else
+                            {
+                                @for (int j = 0; j < phoneNumber.Length; j++)
+                                {
+                                    // if the string contains "(xxx)"
+                                    if (phoneNumber[j] == '(' && phoneNumber[j + 4] == ')')
+                                    {
+                                        @if (j > 0) {
+                                            <br>
+                                        }
+                                        // display phone number as clickable number and move to the end of it
+                                        <a href="tel:@phoneNumber.Substring(j, 14)">@phoneNumber.Substring(j, 14)</a>
+                                        j += 14;
+                                    }
+                                    else // display the character
+                                    {
+                                        @phoneNumber[j];
+                                    }                          
+                                }
+                            }
+                            <br />
                         }
-                        </td>
-                    }
-                    else
-                    {
-                        <td></td>
-                    }
-                    @if (Model.Agencies[i].Email != null)
-                    {
-                        string email = Model.Agencies[i].Email;
-                        int emailStart = 0;
-                        
-                        <td>
+
+                        @if (Model.Agencies[i].Email != null)
+                        {
+                            string email = Model.Agencies[i].Email;
+                            int emailStart = 0;
+
                             @*separate multiple emails*@
                             @for (int j = 0; j < email.Length; j++)
                             {
@@ -277,17 +264,13 @@ else
                                     emailStart = j;
                                 }
                             }
-                            @{ // display link as final email
-                                string finalEmail = email.Substring(emailStart, email.Length - emailStart);
-                            }
+                             // display link as final email
+                             string finalEmail = email.Substring(emailStart, email.Length - emailStart);
+                            
                             <a href="mailto:@finalEmail.Trim()">@finalEmail</a>
+                        }
+                    </td>
 
-                        </td>
-                    }
-                    else
-                    {
-                        <td></td>
-                    }
                     @if (Model.Agencies[i].City != null)
                     {
                         <td>@Model.Agencies[i].City : @Model.Agencies[i].Zip</td>

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -190,7 +190,7 @@ else
         <h1>
             @if (Model.Category != null && Model.CurrentCity != null)
             {
-                @:@Model.Category.AgencyCategoryName - @Model.CurrentCity
+                @: @Model.Category.AgencyCategoryName - @Model.CurrentCity
             }
             else if (Model.Category != null)
             {
@@ -205,19 +205,19 @@ else
         <div id="scrollResults" class="container">
             @for (int i = 0; i < Model.Agencies.Count; i++)
             {
-                <div class="row py-1 results @(i % 2 == 0 ? "evenIndex-row" : "")">
-                    <div class="col-md-5">
+                <div class="row py-1 results @(i % 2 == 0 ? "evenIndex-row" : "")"> <!--css for evenIndex-row to emulate striped table-->
+                    <div class="col-md-5 col-9">
                         @Model.Agencies[i].AgencyName 
                         @if (Model.CurrentCity == null && Model.Agencies[i].City != null)
                         {
-                            @(" - " + Model.Agencies[i].City)
+                            @(" - " + Model.Agencies[i].City) <!--if user leaves City blank is search append City-->
                         }
                         @if (Model.Agencies[i].AgencyName2 != null)
                         {
                             <p id="agencyName2"> @Model.Agencies[i].AgencyName2 </p>
                         }
                     </div>
-                    <div class="col-md-5">
+                    <div class="col-md-5 col-9">
                         @if (Model.Agencies[i].Phone != null)
                         {
                             string phoneNumber = Model.Agencies[i].Phone;
@@ -276,7 +276,7 @@ else
                         }
                         </div>
 
-                        <div class="col-1">
+                    <div class="col-md-1 col-2">
                             <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#detailsModal-@i">
                                 Details
                             </button>

--- a/PC2/Views/Resources/ResourceGuide.cshtml
+++ b/PC2/Views/Resources/ResourceGuide.cshtml
@@ -185,22 +185,23 @@
 else
 {
     <div id="results" class="container">
-        @if (Model.Category != null)
-        {
+
             <div class="row">
-                <div class="col-12">
-                    <h1>@Model.Category.AgencyCategoryName</h1>
-                </div>
-            </div>
+            <h1>
+                @if (Model.Category != null && Model.CurrentCity != null)
+                {
+                    @:@Model.Category.AgencyCategoryName - @Model.CurrentCity
         }
+                else if (Model.Category != null)
+                {
+                    @: @Model.Category.AgencyCategoryName
+                }
         else if (Model.CurrentCity != null)
         {
-            <div class="row">
-                <div class="col-12">
-                    <h1>@Model.CurrentCity</h1>
+                    @: @Model.CurrentCity
+                }
+            </h1>
                 </div>
-            </div>
-        }
         <div id="scrollResults" class="container">
             @for (int i = 0; i < Model.Agencies.Count; i++)
             {

--- a/PC2/wwwroot/css/site.css
+++ b/PC2/wwwroot/css/site.css
@@ -579,7 +579,7 @@ li {
 /* Emulate alternating background colors of table-striped for
    the <div> rows of the Resource guide table
 */
-.evenIndex-row {
+div.results:nth-child(even) {
     background-color: #f2f2f2;
 }
 div.results:hover, div.results:hover #agencyName2 {

--- a/PC2/wwwroot/css/site.css
+++ b/PC2/wwwroot/css/site.css
@@ -591,6 +591,3 @@ div.results:hover, div.results:hover #agencyName2 {
     max-height : 550px;
     overflow-y: auto;
 }
-    padding-bottom: .5em;
-    padding-top: .5em;
-}

--- a/PC2/wwwroot/css/site.css
+++ b/PC2/wwwroot/css/site.css
@@ -482,6 +482,11 @@ main p {
     margin-bottom: 0;
 }
 
+#agencyName2 {
+    font-size: .9em;
+    color: rgb(41, 41, 41);
+}
+
 #photo-header {
     margin: auto;
     clear: both;

--- a/PC2/wwwroot/css/site.css
+++ b/PC2/wwwroot/css/site.css
@@ -568,3 +568,8 @@ div.results:hover, div.results:hover #agencyName2 {
     color: white;
     background-color: #88b235;
 }
+
+#scrollResults {
+    height: 650px; /* Set to the height you want */
+    overflow-y: auto; /* Makes the container scrollable */
+}

--- a/PC2/wwwroot/css/site.css
+++ b/PC2/wwwroot/css/site.css
@@ -557,3 +557,14 @@ main p {
 li {
     padding-bottom: 1em;
 }
+
+/* Emulate alternating background colors of table-striped for
+   the <div> rows of the Resource guide table
+*/
+.odd-row {
+    background-color: #f2f2f2; /* Change this to the color you want for odd rows */
+}
+div.results:hover, div.results:hover #agencyName2 {
+    color: white;
+    background-color: #88b235;
+}

--- a/PC2/wwwroot/css/site.css
+++ b/PC2/wwwroot/css/site.css
@@ -561,7 +561,7 @@ li {
 /* Emulate alternating background colors of table-striped for
    the <div> rows of the Resource guide table
 */
-.odd-row {
+.evenIndex-row {
     background-color: #f2f2f2; /* Change this to the color you want for odd rows */
 }
 div.results:hover, div.results:hover #agencyName2 {
@@ -570,6 +570,6 @@ div.results:hover, div.results:hover #agencyName2 {
 }
 
 #scrollResults {
-    height: 650px; /* Set to the height you want */
+    max-height : 550px; /* Set to the height you want */
     overflow-y: auto; /* Makes the container scrollable */
 }


### PR DESCRIPTION
I combined AgencyName 1 & 2 and Phone & Email fields in columns to save on width and changed the table into divs for better flexibility. When screen size becomes small the list changes into a stacked view. I added CSS to emulate table striped and hover and overlay for scrolling. Edited ResourceGuide POST to fix issue with Category and CurrentCity not being saved when user searches both, can now populate results h1 with Category - City