### PR TITLE
Pull Request for Issue#305

### DIFF
--- a/PC2/Models/People.cs
+++ b/PC2/Models/People.cs
@@ -45,7 +45,7 @@ namespace PC2.Models
         /// <summary>
         /// The staff/person's email address.
         /// </summary>
-        public string Email { get; set; }
+        public required string Email { get; set; }
 
         /// <summary>
         /// Gets a formatted display of the phone number and extension.


### PR DESCRIPTION
Just added the required keyword to the Email property inside of the People class. However nulls can still be added to the database through the Email property. No errors when leaving the Email field blank on the web form and submitting it and it gets passed as a null.

Closes #305 