### PR TITLE
Move Board class to People.cs and add documentation

### DIFF
--- a/PC2/Models/Board.cs
+++ b/PC2/Models/Board.cs
@@ -1,7 +1,0 @@
-﻿namespace PC2.Models
-{
-    public class Board : People
-    {
-        public string MembershipStart { get; set; }
-    }
-}

--- a/PC2/Models/People.cs
+++ b/PC2/Models/People.cs
@@ -80,4 +80,15 @@ namespace PC2.Models
     {
     
     }
+
+    /// <summary>
+    /// Represents a board member, inheriting basic information from <see cref="People"/>.
+    /// </summary>
+    public class Board : People
+    {
+        /// <summary>
+        /// The start date of the board membership.
+        /// </summary>
+        public string MembershipStart { get; set; }
+    }
 }


### PR DESCRIPTION
The Board class was moved from Board.cs to People.cs within the PC2.Models namespace. The class now includes XML documentation comments for better code documentation and understanding. The functionality of the Board class remains the same, with the MembershipStart property still present.