### PR TITLE
Hide empty steering committee member section

### DIFF
--- a/PC2/Views/Home/About.cshtml
+++ b/PC2/Views/Home/About.cshtml
@@ -100,19 +100,22 @@
             </tbody>
         </table>
     </div>
-    <h2>Our Steering Committee</h2>
-    <div class="steering-column">
-        <table class="table">
-            <tbody>
-                @for (int i = 0; i < Model.SteeringCommittee.Count; i++)
-                {
-                    <tr>
-                        <td>
-                            <p>@Model.SteeringCommittee[i].Name</p>
-                            <p>@Model.SteeringCommittee[i].Title</p>
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-    </div>
+    @if (Model.SteeringCommittee.Count > 0)
+    {
+        <h2>Our Steering Committee</h2>
+        <div class="steering-column">
+            <table class="table">
+                <tbody>
+                    @for (int i = 0; i < Model.SteeringCommittee.Count; i++)
+                    {
+                        <tr>
+                            <td>
+                                <p>@Model.SteeringCommittee[i].Name</p>
+                                <p>@Model.SteeringCommittee[i].Title</p>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }


### PR DESCRIPTION
The client has informed us the steering committee is inactive at this time. Instead of removing it from the codebase, this PR does not show the steering committee section on the about page if there are no members