### PR TITLE
Refactor registration endpoint routing

### DIFF
--- a/PC2/Program.cs
+++ b/PC2/Program.cs
@@ -79,9 +79,10 @@ IdentityHelper.CreateDefaultAdmin(serviceProvider.ServiceProvider, IdentityHelpe
 #endif
 
 // If a user tries to access the register page, redirect them to the login page
-app.MapGet("/Identity/Account/Register", context => 
-    Task.Factory.StartNew(() => context.Response.Redirect("/Identity/Account/Login", true, true)));
-app.MapPost("/Identity/Account/Register", context => 
-    Task.Factory.StartNew(() => context.Response.Redirect("/Identity/Account/Login", true, true)));
+app.Map("/Identity/Account/Register", async context =>
+{
+    context.Response.Redirect("/Identity/Account/Login", true, true);
+    await Task.CompletedTask;
+});
 
 app.Run();

--- a/PC2/Program.cs
+++ b/PC2/Program.cs
@@ -77,11 +77,11 @@ IdentityHelper.CreateRoles(serviceProvider.ServiceProvider, IdentityHelper.Admin
 IdentityHelper.CreateDefaultAdmin(serviceProvider.ServiceProvider, IdentityHelper.Admin)
               .Wait();
 #endif
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapGet("/Identity/Account/Register", context => Task.Factory.StartNew(() => context.Response.Redirect("/Identity/Account/Login", true, true)));
-    endpoints.MapPost("/Identity/Account/Register", context => Task.Factory.StartNew(() => context.Response.Redirect("/Identity/Account/Login", true, true)));
 
-});
+// If a user tries to access the register page, redirect them to the login page
+app.MapGet("/Identity/Account/Register", context => 
+    Task.Factory.StartNew(() => context.Response.Redirect("/Identity/Account/Login", true, true)));
+app.MapPost("/Identity/Account/Register", context => 
+    Task.Factory.StartNew(() => context.Response.Redirect("/Identity/Account/Login", true, true)));
 
 app.Run();


### PR DESCRIPTION
Updated the handling of requests to the "/Identity/Account/Register" endpoint by replacing `endpoints.MapGet` and `endpoints.MapPost` within an `app.UseEndpoints` block with direct calls to `app.MapGet` and `app.MapPost`. This change simplifies the routing configuration and ensures users are redirected to the "/Identity/Account/Login" page when accessing the registration page.

The older style MapEndpoints is no longer recommended