### PR TITLE
Tests

### DIFF
--- a/PC2Tests/ConfigTests/AppSettingsConfigTests.cs
+++ b/PC2Tests/ConfigTests/AppSettingsConfigTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.Configuration;
+using System.IO;
+
+namespace PC2.Configuration.Tests;
+
+[TestClass]
+public class AppSettingsConfigTests
+{
+    private IConfigurationRoot _config;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // appsettings.json is copied to the test project output directory in the .csproj file
+        var builder = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false);
+        _config = builder.Build();
+    }
+
+    [TestMethod]
+    public void PC2SendGridAPIKey_IsPresent()
+    {
+        var section = _config["PC2SendGridAPIKey"];
+        Assert.IsNotNull(section, "PC2SendGridAPIKey is missing in appsettings.json");
+    }
+
+    [TestMethod]
+    public void PC2Email_IsPresent()
+    {
+        var section = _config["PC2Email"];
+        Assert.IsNotNull(section, "PC2Email is missing in appsettings.json");
+    }
+
+    [TestMethod]
+    public void PC2NoReplyEmail_IsPresent()
+    {
+        var section = _config["PC2NoReplyEmail"];
+        Assert.IsNotNull(section, "PC2NoReplyEmail is missing in appsettings.json");
+    }
+
+    [TestMethod]
+    public void DefaultConnection_IsPresentAndNotEmpty()
+    {
+        var value = _config.GetSection("ConnectionStrings")["DefaultConnection"];
+        Assert.IsFalse(string.IsNullOrWhiteSpace(value), "DefaultConnection is missing or empty in appsettings.json");
+    }
+
+    [TestMethod]
+    public void AzureBlob_ContainerName_IsPresentAndNotEmpty()
+    {
+        var value = _config.GetSection("AzureBlob")["ContainerName"];
+        Assert.IsFalse(string.IsNullOrWhiteSpace(value), "AzureBlob:ContainerName is missing or empty in appsettings.json");
+    }
+
+    [TestMethod]
+    public void AzureBlob_BlobServiceUri_IsPresentAndNotEmpty()
+    {
+        var value = _config.GetSection("AzureBlob")["BlobServiceUri"];
+        Assert.IsFalse(string.IsNullOrWhiteSpace(value), "AzureBlob:BlobServiceUri is missing or empty in appsettings.json");
+    }
+}

--- a/PC2Tests/Models/EmailSenderTests.cs
+++ b/PC2Tests/Models/EmailSenderTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using IdentityLogin.Models;
+using Moq;
+using System.Threading.Tasks;
+
+namespace PC2.Models.Tests;
+
+[TestClass]
+public class EmailSenderTests
+{
+    private Mock<IEmailSender> _mockEmailSender;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockEmailSender = new Mock<IEmailSender>();
+    }
+
+    [TestMethod]
+    public async Task SendEmailAsync_CalledWithCorrectParameters()
+    {
+        // Arrange
+        var name = "Test User";
+        var email = "testuser@example.com";
+        var phone = "1234567890";
+        var subject = "Test Subject";
+        var message = "Test Message";
+
+        _mockEmailSender
+            .Setup(sender => sender.SendEmailAsync(name, email, phone, subject, message))
+            .ReturnsAsync(new SendGrid.Response(System.Net.HttpStatusCode.OK, null, null));
+
+        // Act
+        var response = await _mockEmailSender.Object.SendEmailAsync(name, email, phone, subject, message);
+
+        // Assert
+        Assert.IsNotNull(response);
+        Assert.IsInstanceOfType(response, typeof(SendGrid.Response));
+        _mockEmailSender.Verify(sender => sender.SendEmailAsync(name, email, phone, subject, message), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task SendEmailAsync_ReturnsExpectedResponse()
+    {
+        // Arrange
+        var expectedResponse = new SendGrid.Response(System.Net.HttpStatusCode.OK, null, null);
+        _mockEmailSender
+            .Setup(sender => sender.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var response = await _mockEmailSender.Object.SendEmailAsync("name", "email", "phone", "subject", "message");
+
+        // Assert
+        Assert.AreEqual(expectedResponse, response);
+    }
+}

--- a/PC2Tests/PC2Tests.csproj
+++ b/PC2Tests/PC2Tests.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest" Version="3.6.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest" Version="3.10.4" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,6 +19,13 @@
 
   <ItemGroup>
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\PC2\appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>appsettings.json</Link>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added some Unit Tests while testing Code Coverage in VS 2026 Community

This pull request adds new unit tests for configuration and email sending functionality, updates test dependencies, and ensures the `appsettings.json` configuration file is available for tests. The changes improve test coverage for critical app settings and email sending logic, and update the test project setup for modern dependencies and configuration management.

**Testing enhancements:**

* Added `AppSettingsConfigTests` to verify required configuration values are present and non-empty in `appsettings.json`, including connection strings and Azure Blob settings.
* Added `EmailSenderTests` using Moq to test that `IEmailSender.SendEmailAsync` is called with correct parameters and returns expected responses.

**Project setup improvements:**

* Updated NuGet package references in `PC2Tests.csproj` to newer versions of `Microsoft.NET.Test.Sdk`, `MSTest`, and added `Moq` for mocking.
* Configured `PC2Tests.csproj` to copy `appsettings.json` from the main project into the test output directory, ensuring tests have access to configuration values.