### PR TITLE
Add validRange to limit calendar interactions by date

### DIFF
--- a/PC2/Views/Events/Index.cshtml
+++ b/PC2/Views/Events/Index.cshtml
@@ -128,12 +128,12 @@
                 myModal.show();
             },
 
-            validRange: function(nowDate) {
+            validRange: function(currentDate) {
                 // Today's date
-                const start = new Date(nowDate);
+                const start = new Date(currentDate);
 
                 // Sets end to 1 year in future based on today's date
-                const end = new Date(nowDate);
+                const end = new Date(currentDate);
                 end.setMonth(end.getMonth() + 12);
 
                 return { start, end };


### PR DESCRIPTION
Closes #407
Added a `validRange` function to the calendar configuration to dynamically restrict the calendar's valid date range. The range starts from today's date and ends one year in the future, ensuring users can only interact with dates within this range.