### PR TITLE
Issue #432 - Handle null Agency in Agency controller edit action

### DIFF
--- a/PC2/Controllers/AgencyController.cs
+++ b/PC2/Controllers/AgencyController.cs
@@ -51,7 +51,13 @@ namespace PC2.Controllers
         [HttpGet]
         public async Task<IActionResult> Edit(int id)
         {
-            Agency agency = await AgencyDB.GetAgencyAsync(_context, id);
+            Agency? agency = await AgencyDB.GetAgencyAsync(_context, id);
+
+            if (agency == null)
+            {
+                return NotFound();
+            }
+
             ViewData["ExistingServices"] = agency.AgencyCategories;
             ViewData["Categories"] = await AgencyCategoryDB.GetAgencyCategoriesAsync(_context);
             return View(agency);

--- a/PC2/Data/AgencyDB.cs
+++ b/PC2/Data/AgencyDB.cs
@@ -149,6 +149,12 @@ namespace PC2.Data
                 .ToListAsync();
         }
 
+        /// <summary>
+        /// Asynchronously retrieves an agency by its unique identifier, including its associated categories.
+        /// </summary>
+        /// <param name="id">The unique identifier of the agency to retrieve.</param>
+        /// <returns>Result contains the agency with the specified
+        /// identifier, or null if no such agency exists.</returns>
         public static async Task<Agency?> GetAgencyAsync(ApplicationDbContext context, int id)
         {
             return await (from a in context.Agency


### PR DESCRIPTION
Closes #432 

Updated the `Edit` action in `AgencyController` to handle cases where the `Agency` object is `null` by returning a `NotFound()` result. Declared the `Agency` object as nullable (`Agency?`) to reflect this possibility.

Documented `GetAgencyAsync` method in `AgencyDB` to retrieve an `Agency` by its unique identifier

=========== COPILOT SUMMARY ================
This pull request improves the robustness and clarity of agency retrieval in the application. The main changes focus on handling cases where an agency is not found and documenting the agency retrieval method.

Error handling improvements:

* Updated the `Edit` action in `AgencyController.cs` to return a `NotFound` result if the agency does not exist, preventing errors from null references.

Documentation and code clarity:

* Added XML documentation to the `GetAgencyAsync` method in `AgencyDB.cs`, explaining its purpose, parameters, and return value.