### PR TITLE
Correct link to admin analytic.js

### DIFF
--- a/PC2/Views/Admin/Analytics.cshtml
+++ b/PC2/Views/Admin/Analytics.cshtml
@@ -412,5 +412,5 @@
             ]
         };
     </script>
-	<script src="~/js/admin-analytics.js"></script>
+	<script src="~/js/analytics.js"></script>
 }


### PR DESCRIPTION
Summary
---
Link to analytics JS file had the incorrect name on the view

Copilot Summary
---
This pull request makes a minor update to the analytics script reference in the `Analytics.cshtml` view, switching to the correct name.

- Changed the script source from `admin-analytics.js` to `analytics.js` in the `PC2/Views/Admin/Analytics.cshtml` file.
