### PR TITLE
Migrate analytics to explicit managed identity

### DIFF
--- a/PC2/Services/AnalyticsService.cs
+++ b/PC2/Services/AnalyticsService.cs
@@ -23,28 +23,23 @@ public class AnalyticsService
         _workspaceId = configuration["ApplicationInsights:WorkspaceId"];
         var connectionString = configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
 
-        // Only initialize Azure client if both workspace ID and connection string are configured
-        if (!string.IsNullOrEmpty(_workspaceId) && !string.IsNullOrEmpty(connectionString))
+#if !DEBUG
+        try
         {
-            try
-            {
-                _logsQueryClient = new LogsQueryClient(new ManagedIdentityCredential());
-                _isAzureConfigured = true;
-                _logger.LogInformation("Successfully initialized Azure Application Insights client");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to initialize Azure Application Insights client");
-                _logger.LogWarning("Falling back to local Application Insights data");
-                _isAzureConfigured = false;
-            }
+            _logsQueryClient = new LogsQueryClient(new ManagedIdentityCredential());
+            _isAzureConfigured = true;
+            _logger.LogInformation("Successfully initialized Azure Application Insights client");
         }
-        else
+        catch (Exception ex)
         {
-            // Use local Application Insights telemetry
-            _logger.LogInformation("Azure Application Insights not configured. Using local telemetry data");
+            _logger.LogError(ex, "Failed to initialize Azure Application Insights client");
+            _logger.LogWarning("Falling back to local Application Insights data");
             _isAzureConfigured = false;
         }
+#else
+        // Use local hardcoded data for dev
+        _isAzureConfigured = false;
+#endif
     }
 
     /// <summary>
@@ -63,7 +58,7 @@ public class AnalyticsService
 
         try
         {
-            if (_isAzureConfigured && _logsQueryClient != null && !string.IsNullOrEmpty(_workspaceId))
+            if (_isAzureConfigured && _logsQueryClient != null)
             {
                 // Use Azure Application Insights Log Analytics
                 await GetAzureAnalyticsDataAsync(viewModel);
@@ -179,7 +174,7 @@ public class AnalyticsService
     {
         var pageViews = new List<PageViewData>();
 
-        if (_logsQueryClient == null || string.IsNullOrEmpty(_workspaceId))
+        if (_logsQueryClient == null)
             return pageViews;
 
         try
@@ -232,7 +227,7 @@ public class AnalyticsService
     {
         var downloads = new List<DownloadData>();
 
-        if (_logsQueryClient == null || string.IsNullOrEmpty(_workspaceId))
+        if (_logsQueryClient == null)
             return downloads;
 
         try
@@ -285,7 +280,7 @@ public class AnalyticsService
     {
         var searchTerms = new List<SearchTermData>();
 
-        if (_logsQueryClient == null || string.IsNullOrEmpty(_workspaceId))
+        if (_logsQueryClient == null)
             return searchTerms;
 
         try


### PR DESCRIPTION
Summary
---
Simplifying the Application Insights log query code and using ManagedIdentity explicitly instead of relying on AzureDefaultCredential to select the ManagedIdentity in the production environment.

Copilot Summary
---
This pull request updates the initialization and usage of the Azure Application Insights client in the `AnalyticsService` to improve environment handling and simplify Azure configuration checks. The most important changes include switching to `ManagedIdentityCredential` for authentication, using conditional compilation to separate development and production logic, and removing unnecessary workspace ID checks throughout the service.

**Environment-specific initialization:**

* The Azure Application Insights client (`_logsQueryClient`) is now initialized using `ManagedIdentityCredential` instead of `DefaultAzureCredential`, and only in non-DEBUG builds. In DEBUG builds, local hardcoded data is used for development. [[1]](diffhunk://#diff-b08afd99bb7d9a6ed58979f8523ba0da086e790df41cda19bd20263ed961616fL26-R29) [[2]](diffhunk://#diff-b08afd99bb7d9a6ed58979f8523ba0da086e790df41cda19bd20263ed961616fL43-R42)

**Simplification of Azure configuration checks:**

* Removed redundant checks for workspace ID when determining if Azure analytics should be used; now only checks for `_isAzureConfigured` and `_logsQueryClient` throughout the service methods (`GetAnalyticsDataAsync`, `GetPageViewsAsync`, `GetPdfDownloadsAsync`, `GetSearchTermsAsync`). [[1]](diffhunk://#diff-b08afd99bb7d9a6ed58979f8523ba0da086e790df41cda19bd20263ed961616fL68-R61) [[2]](diffhunk://#diff-b08afd99bb7d9a6ed58979f8523ba0da086e790df41cda19bd20263ed961616fL184-R177) [[3]](diffhunk://#diff-b08afd99bb7d9a6ed58979f8523ba0da086e790df41cda19bd20263ed961616fL237-R230) [[4]](diffhunk://#diff-b08afd99bb7d9a6ed58979f8523ba0da086e790df41cda19bd20263ed961616fL290-R283)
