### PR TITLE
Update analytics query to show top 50 page views

### DIFF
--- a/PC2/Services/AnalyticsService.cs
+++ b/PC2/Services/AnalyticsService.cs
@@ -191,11 +191,13 @@ public class AnalyticsService
             // This filter can be safely removed in the future once the old server data falls off.
             var query = $@"
                     AppPageViews
-                    | where TimeGenerated between (datetime({startDate}) .. datetime({endDate}))
+                    | where TimeGenerated between (datetime({startDate:yyyy-MM-ddTHH:mm:ssZ}) .. datetime({endDate:yyyy-MM-ddTHH:mm:ssZ}))
                     | where isempty(SyntheticSource)
                     | where ClientType == 'Browser' or ClientType == 'PC'
-                    | where isnotempty(UserId)  // Only count users with valid IDs
-                    | summarize UniqueUsers = dcount(UserId)";
+                    | where Name !startswith '/'
+                    | summarize ViewCount = count() by Name
+                    | order by ViewCount desc
+                    | limit 50";
 
             Response<LogsQueryResult> response = await _logsQueryClient.QueryWorkspaceAsync(
                 _workspaceId,


### PR DESCRIPTION
<!-- Reference the issue(s) this PR is for -->
Closes #459 

Summary
---
Fixed bug in Kusto query to pull top page views.

Copilot Summary
---
This pull request updates the Kusto query in the `GetPageViewsAsync` method of `AnalyticsService.cs` to improve how page view analytics are calculated and reported. The changes shift the focus from counting unique users to summarizing and ranking page views by page name, while also refining the filtering criteria.

Analytics query improvements:

* Modified the query to summarize and order page views by page `Name`, returning the top 50 most viewed pages instead of counting unique users by `UserId`.
* Updated the date formatting in the query to use the `yyyy-MM-ddTHH:mm:ssZ` format for `startDate` and `endDate`, ensuring correct time zone handling.
* Added a filter to exclude entries where `Name` starts with `/`, likely to remove system or invalid page names from the analytics.
* Removed the filter that only counted users with valid `UserId`, as the focus is now on page view counts rather than unique users.
