### PR TITLE
Remove custom submenu CSS and simplify nav styles

### DIFF
--- a/PC2/wwwroot/css/site.css
+++ b/PC2/wwwroot/css/site.css
@@ -163,7 +163,7 @@ main {
     height: 130px;
 }
 
-#bootstrap-override nav, #bootstrap-override nav button, .menu-item, #menu-bar, .submenu, .divider, .dropdown-menu {
+#bootstrap-override nav, #bootstrap-override nav button, .menu-item, #menu-bar, .divider, .dropdown-menu {
     background-color: rgba(18, 66, 35, 1);
 }
 
@@ -190,14 +190,11 @@ body > .container {
 ul.navbar-nav, .dropdown-item {
     text-align: center;
     justify-content: space-around;
-    -webkit-justify-content: space-around; /*Safari 6.1+*/
-    display: -webkit-flex; /*Safari*/
     max-width: 950px;
     margin: 0 auto;
 }
 
 .navbar-nav .dropdown-menu {
-    position: absolute;
     border: 2px solid black;
 }
 
@@ -248,12 +245,9 @@ nav .container {
 }
 
 /*text color transition when hovered*/
-#bootstrap-override .menu-item:hover > a, #bootstrap-override .submenu-item:hover > a {
+#bootstrap-override .menu-item:hover > a {
     color: black;
     transition: color .4s ease 0s;
-    -webkit-transition: color .4s ease 0s;
-    -moz-transition: color .4s ease 0s;
-    -o-transition: color .4s ease 0s;
 }
 
 .menu-item {
@@ -264,19 +258,15 @@ nav .container {
 }
 
 /*background color transition when hovered*/
-.menu-item:hover, .submenu-item:hover {
+.menu-item:hover {
     background-color: rgba(180, 204, 132, 1);
     transition: background-color .4s ease 0s;
-    -webkit-transition: background-color .4s ease 0s;
-    -moz-transition: background-color .4s ease 0s;
 }
 
 /*changes text color to provide contrast*/
 .nav-link:hover {
     color: black !important;
     transition: background-color .4s ease 0s;
-    -webkit-transition: background-color .4s ease 0s;
-    -moz-transition: background-color .4s ease 0s;
 }
 
 nav a {
@@ -300,43 +290,6 @@ nav a {
 #right-ribbon {
     border-left-width: 0;
     right: 0;
-}
-
-.submenu-container {
-    padding: 15px 0 0 0;
-    background-color: transparent;
-    position: absolute;
-    left: 50%;
-    top: 60px;
-    -webkit-transform: translate(-50%, 0%);
-    -ms-transform: translate(-50%, 0%);
-    -moz-transform: translate(-50%, 0%);
-    -o-transform: translate(-50%, 0%);
-    transform: translate(-50%, 0%);
-    z-index: 11;
-}
-
-#bootstrap-override .submenu-item a {
-    white-space: nowrap;
-    padding: 4px 7px 9px 7px;
-    text-align: center;
-}
-
-.submenu-item {
-    height: 30px;
-    list-style-type: none;
-}
-
-#bootstrap-override .submenu {
-    padding: 0;
-    position: static;
-    margin: 0;
-    border-radius: 0;
-    min-width: 90px;
-}
-
-.priority > a {
-    z-index: 10;
 }
 
 .dropdown-toggle {


### PR DESCRIPTION
Summary
---
Removed all custom submenu-related CSS, including styling and hover effects for .submenu-container, .submenu-item, and .submenu classes. Cleaned up vendor-prefixed transitions and retained main menu item hover/background styles. Navigation now relies on default Bootstrap dropdown behavior.


Copilot Summary
---
This pull request makes several simplifications and cleanups to the navigation and menu-related CSS in `site.css`. The main focus is on removing unused or redundant styles, especially those related to submenus, and on reducing vendor-prefixed properties for a more modern and maintainable codebase.

**Navigation and submenu CSS cleanup:**

* Removed all CSS rules related to `.submenu-container`, `.submenu-item`, and `#bootstrap-override .submenu`, including positioning, padding, and styling, as these submenu structures are no longer used or required.
* Removed `.submenu` and `.submenu-item` from various selectors, reflecting that submenu-specific styles are no longer necessary. [[1]](diffhunk://#diff-096b71ed93c8ecce1da7bace01818627e24267ec7221d534d92fa8acb0d9986eL166-R166) [[2]](diffhunk://#diff-096b71ed93c8ecce1da7bace01818627e24267ec7221d534d92fa8acb0d9986eL251-L256) [[3]](diffhunk://#diff-096b71ed93c8ecce1da7bace01818627e24267ec7221d534d92fa8acb0d9986eL267-L279)

**Vendor prefix and legacy property removal:**

* Removed all vendor-prefixed transition properties (`-webkit-`, `-moz-`, `-o-`) for color and background-color transitions, relying on standard CSS for modern browser support. [[1]](diffhunk://#diff-096b71ed93c8ecce1da7bace01818627e24267ec7221d534d92fa8acb0d9986eL251-L256) [[2]](diffhunk://#diff-096b71ed93c8ecce1da7bace01818627e24267ec7221d534d92fa8acb0d9986eL267-L279)

**General navigation style adjustments:**

* Removed the `position: absolute;` property from `.navbar-nav .dropdown-menu` to allow for default Bootstrap positioning.
* Removed `display: -webkit-flex;` and `-webkit-justify-content` from navigation layout, as standard flexbox is sufficient.

These changes help modernize the stylesheet, reduce complexity, and ensure that only actively used navigation elements are styled.