### PR TITLE
Remove placeholder message and fix typo in Governor link

### DIFF
--- a/PC2/Views/Resources/LegislativeLinksAndEvents.cshtml
+++ b/PC2/Views/Resources/LegislativeLinksAndEvents.cshtml
@@ -23,7 +23,6 @@
 
 <div class="divider"></div>
 
-<p>Legislature Contact information for 2026 coming soon.</p>
 @* <div class="pdf-link">
     <p><a href="~/PDF/legislative-links/LegislatorsPage2025.pdf" target="_blank">Click Here</a> for a pdf of the contact sheet below.</p>
     <br />
@@ -48,7 +47,7 @@
 <div class="links">
     <h2>Legislative Links:</h2>
     <br />
-    <a href="https://www.governor.wa.gov/">Washington Govenor</a>
+    <a href="https://www.governor.wa.gov/">Washington Governor</a>
     <br />
     <br />
     <a href="https://leg.wa.gov/">Washington State Legislature</a>


### PR DESCRIPTION
Edits based on client request. Removed the "Legislature Contact information for 2026 coming soon." placeholder from the page. Corrected a typo in the legislative links section, changing "Washington Govenor" to "Washington Governor".